### PR TITLE
Fixed edgeSwipe variable names in config files.

### DIFF
--- a/eventKey.cfg
+++ b/eventKey.cfg
@@ -26,15 +26,15 @@
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right   =>  "LCT/TAB",       # ctrl + tab
         left    =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -64,15 +64,15 @@
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right   =>  "LCT/TAB",       # ctrl + tab
         left    =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -102,15 +102,15 @@
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right   =>  "LCT/TAB",       # ctrl + tab
         left    =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -140,15 +140,15 @@
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -178,15 +178,15 @@
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right   =>  "LCT/TAB",       # ctrl + tab
         left    =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }

--- a/nScroll/eventKey.cfg
+++ b/nScroll/eventKey.cfg
@@ -26,15 +26,15 @@
         up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -64,15 +64,15 @@
         up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -102,15 +102,15 @@
         up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -140,15 +140,15 @@
         up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }
@@ -178,15 +178,15 @@
         up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
-    edgeSwipe2=>{
+    edge_swipe2=>{
         right    =>  "LCT/TAB",       # ctrl + tab
         left     =>  "LSH/LCT/TAB",   # shift + ctrl + tab
     },
-    edgeSwipe3=>{
+    edge_swipe3=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     },
-    edgeSwipe4=>{
+    edge_swipe4=>{
         down    =>  "LAL/F4",        # alt + F4
         up      =>  "LCT/LAL/t",     # ctrl + alt + t
     }


### PR DESCRIPTION
    Edge swiping doesn't currently work with the provided config files because xSwipe.pl expects snake_case, but the edge swipe strings are in camelCase.