### PR TITLE
Changed "DOW" to "DOWN"

### DIFF
--- a/eventKey.cfg
+++ b/eventKey.cfg
@@ -8,7 +8,7 @@
     swipe3=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         up      =>  "LCT/LAL/UP",    # ctrl + alt +  up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -22,7 +22,7 @@
     swipe5=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -46,7 +46,7 @@
     swipe3 =>{
         right   =>  "LCT/LAL/RIG",   # ctrl + alt +  right
         left    =>  "LCT/LAL/LEF",   # ctrl + alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         up      =>  "LCT/LAL/UP",    # ctrl + alt +  up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -60,7 +60,7 @@
     swipe5=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -84,7 +84,7 @@
     swipe3 =>{
         right   =>  "LCT/LAL/RIG",   # ctrl + alt +  right
         left    =>  "LCT/LAL/LEF",   # ctrl + alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         up      =>  "LCT/LAL/UP",    # ctrl + alt +  up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -98,7 +98,7 @@
     swipe5=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -136,7 +136,7 @@
     swipe5=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },
@@ -167,14 +167,14 @@
     swipe4=>{
         right   =>  "LCT/LAL/RIG",   # ctrl + alt +  right
         left    =>  "LCT/LAL/LEF",   # ctrl + alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         up      =>  "LCT/LAL/UP",    # ctrl + alt +  up
         press   =>  "LAL/F8",        # alt + F8
     },
     swipe5=>{
         right   =>  "LAL/RIG",       # alt +  right
         left    =>  "LAL/LEF",       # alt +  left
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         up      =>  "LCT/LAL/UP",    # ctrl + alt + up
         press   =>  "LAL/F7",        # alt + F7
     },


### PR DESCRIPTION
X11-guitest had a typo where "DOW" corresponded to the down key. It was fixed on 0.26 Sat Feb 02 2013 14:20.
Corrections made in this file.