### PR TITLE
Changed "DOW" to "DOWN"

### DIFF
--- a/nScroll/eventKey.cfg
+++ b/nScroll/eventKey.cfg
@@ -9,7 +9,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt +  up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         press   =>  "LAL/F7",        # alt + F7
     },
     swipe4=>{
@@ -23,7 +23,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt + up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
     edgeSwipe2=>{
@@ -47,7 +47,7 @@
         right   =>  "LCT/LAL/LEF",   # ctrl + alt +  left
         left    =>  "LCT/LAL/RIG",   # ctrl + alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt +  up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         press   =>  "LAL/F7",        # alt + F7
     },
     swipe4=>{
@@ -61,7 +61,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt + up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
     edgeSwipe2=>{
@@ -85,7 +85,7 @@
         right   =>  "LCT/LAL/LEF",   # ctrl + alt +  left
         left    =>  "LCT/LAL/RIG",   # ctrl + alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt +  up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         press   =>  "LAL/F7",        # alt + F7
     },
     swipe4=>{
@@ -99,7 +99,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt + up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
     edgeSwipe2=>{
@@ -137,7 +137,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt + up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
     edgeSwipe2=>{
@@ -167,7 +167,7 @@
     swipe4=>{
         right   =>  "LCT/LAL/LEF",   # ctrl + alt +  left
         left    =>  "LCT/LAL/RIG",   # ctrl + alt +  right
-        down    =>  "LCT/LAL/DOW",   # ctrl + alt +  down
+        down    =>  "LCT/LAL/DOWN",   # ctrl + alt +  down
         up      =>  "LCT/LAL/UP",    # ctrl + alt +  up
         press   =>  "LAL/F8",        # alt + F8
     },
@@ -175,7 +175,7 @@
         right   =>  "LAL/LEF",       # alt +  left
         left    =>  "LAL/RIG",       # alt +  right
         down    =>  "LCT/LAL/UP",    # ctrl + alt + up
-        up      =>  "LCT/LAL/DOW",   # ctrl + alt + down
+        up      =>  "LCT/LAL/DOWN",   # ctrl + alt + down
         press   =>  "LAL/F7",        # alt + F7
     },
     edgeSwipe2=>{


### PR DESCRIPTION
X11-guitest had a typo where "DOW" corresponded to the down key. It was fixed on 0.26 Sat Feb 02 2013 14:20.
Corrections made in this file.